### PR TITLE
Makefile was not resolving NAME_NGC, $NAME_NGC -> ${NAME_NGC}

### DIFF
--- a/pytorch/Makefile
+++ b/pytorch/Makefile
@@ -13,7 +13,7 @@ install:
 	cd ${PATH_STORAGE} && \
 	wget https://raw.githubusercontent.com/lambdal/deeplearning-benchmark/master/pytorch/setup.sh && \
 	chmod +x setup.sh && \
-	./setup.sh $NAME_NGC
+	./setup.sh ${NAME_NGC}
 
 
 create_data:


### PR DESCRIPTION
A syntax error caused the setup script to fail, script works after adding { } characters