### PR TITLE
Fix typo for NUM_GPU

### DIFF
--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -39,7 +39,7 @@ nvcr.io/nvidia/${NAME_NGC} \
 /bin/bash -c "cp -r /scripts/* /workspace;  ./run_prepare.sh $NAME_DATASET"
 
 # Create benchmark config file
-cp scripts/config_v2/config_pytorch_{NUM_GPU}x${NAME_GPU}_v2.sh scripts/config_v2/config_pytorch_${NAME_TYPE}_{NUM_GPU}x${NAME_GPU}_$(hostname)_v2.sh
+cp scripts/config_v2/config_pytorch_${NUM_GPU}x${NAME_GPU}_v2.sh scripts/config_v2/config_pytorch_${NAME_TYPE}_${NUM_GPU}x${NAME_GPU}_$(hostname)_v2.sh
 
 # Run benchmark
 mkdir -p ${NAME_RESULTS} && \
@@ -50,5 +50,5 @@ docker run --rm --shm-size=1024g \
 -v $(pwd)"/scripts":/scripts \
 -v $(pwd)/${NAME_RESULTS}:/results \
 nvcr.io/nvidia/${NAME_NGC} \
-/bin/bash -c "cp -r /scripts/* /workspace; ./run_benchmark.sh ${NAME_TYPE}_{NUM_GPU}x${NAME_GPU}_$(hostname)_v2 ${NAME_TASKS} 3000"
+/bin/bash -c "cp -r /scripts/* /workspace; ./run_benchmark.sh ${NAME_TYPE}_${NUM_GPU}x${NAME_GPU}_$(hostname)_v2 ${NAME_TASKS} 3000"
 ```


### PR DESCRIPTION
Thank you for creating this useful benchmark. I found the `NUM_GPU` variable expansion was missing a `$` sign, so I added it.